### PR TITLE
Add pointers to in-toto and SLSA

### DIFF
--- a/2022/en/src/K02-supply-chain-vulnerabilities.md
+++ b/2022/en/src/K02-supply-chain-vulnerabilities.md
@@ -12,7 +12,7 @@ Containers take on many forms at different phases of the development lifecycle s
 
 ## How to Prevent
 
-**Image Integrity:** Container images can be thought of as a series of software artifacts and metadata passed from a producer to a consumer. The handoff can be as simple as a developer’s IDE directly to a Kubernetes cluster or as complex as a multi-step dedicated CI/CD workflow. The integrity of the software should be validated through each phase:
+**Image Integrity:** Container images can be thought of as a series of software artifacts and metadata passed from a producer to a consumer. The handoff can be as simple as a developer’s IDE directly to a Kubernetes cluster or as complex as a multi-step dedicated CI/CD workflow. The integrity of the software should be validated through each phase using [in-toto](https://in-toto.io/) [attestations](https://github.com/in-toto/attestation). This also increases the [SLSA](https://slsa.dev) level of the build pipeline, with a higher SLSA level indicating a more resilient build pipeline.
 
 **Software Bill of Materials (SBOM)**: An SBOM provides a list of software packages, licenses, and libraries a given software artifact contains and should be used as a starting point for other security checks. Two of the most popular open standards for SBOM generation include [CycloneDX](https://cyclonedx.org/) and [SPDX](https://spdx.dev/). 
 
@@ -46,4 +46,6 @@ Docker Slim: [https://github.com/docker-slim/docker-slim](https://github.com/doc
 
 Open Policy Agent: [https://www.openpolicyagent.org/](https://www.openpolicyagent.org/)
 
+in-toto: [https://in-toto.io](https://in-toto.io)
 
+SLSA: [https://slsa.dev](https://slsa.dev)


### PR DESCRIPTION
I noticed the prevention mechanisms for the Image Integrity subsections were incomplete. This PR adds pointers to in-toto attestations and the SLSA framework. in-toto attestations can be used to: 1) show provenance for software artifacts as they are built, and 2) ensure there are no gaps between different steps or phases of build processes. SLSA is an open source project developed within the OpenSSF and defines a number of levels and the requirements to meet each level.