### PR TITLE
GitHub capitalization

### DIFF
--- a/2022/en/src/K06-broken-authentication.md
+++ b/2022/en/src/K06-broken-authentication.md
@@ -32,7 +32,7 @@ Service account (SA) tokens can be presented to the Kubernetes API as an authent
 
 ## Example Attack Scenarios
 
-***Accidental Git Leak:*** A developer accidentally checks their `.kubeconfig` file from their laptop which holds Kubernetes authentication credentials for their clusters at work. Someone scanning Github finds the credentials and replays them to the target API (unfortunately, sitting on the internet) and because the cluster is configured to authenticate using certificates, the leaked file has all of the information needed to successfully authenticate to the target cluster. 
+***Accidental Git Leak:*** A developer accidentally checks their `.kubeconfig` file from their laptop which holds Kubernetes authentication credentials for their clusters at work. Someone scanning GitHub finds the credentials and replays them to the target API (unfortunately, sitting on the internet) and because the cluster is configured to authenticate using certificates, the leaked file has all of the information needed to successfully authenticate to the target cluster.
 
 ## References
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ When adopting [Kubernetes](https://kubernetes.io), we introduce new risks to our
 
 ## Get Involved!
 
-Development of this document take place within the source repository on [Github](https://github.com/OWASP/www-project-kubernetes-top-ten).
+Development of this document take place within the source repository on [GitHub](https://github.com/OWASP/www-project-kubernetes-top-ten).
 
 * We are actively looking for organizations and individuals that will provide Kubernetes vulnerability and misconfiguration data.
 * Translation efforts

--- a/index.md
+++ b/index.md
@@ -27,7 +27,7 @@ When adopting [Kubernetes](https://kubernetes.io), we introduce new risks to our
 
 
 ## Getting Involved
-Development, issues, and discussion all take place on the OWASP Top Ten [Github](https://github.com/OWASP/www-project-kubernetes-top-ten) repository. Join the conversation! 
+Development, issues, and discussion all take place on the OWASP Top Ten [GitHub](https://github.com/OWASP/www-project-kubernetes-top-ten) repository. Join the conversation!
 
 ## Licensing
 The Kubernetes OWASP Top 10 document is licensed under the CC BY-NC-SA 4.0, the Creative Commons Attribution-ShareAlike 4.0 license. Some rights reserved.

--- a/info.md
+++ b/info.md
@@ -21,5 +21,5 @@ pitch: none yet
 - [AKS Security Explained](https://www.youtube.com/watch?v=JD3mj5bTOuk)
 
 ### Code Repository
-* [Github Repo](https://github.com/OWASP/www-project-kubernetes-top-ten)
+* [GitHub Repo](https://github.com/OWASP/www-project-kubernetes-top-ten)
 


### PR DESCRIPTION
GitHub is traditionally capitalized as "GitHub", not "Github" (see, e.g., their documentation - https://docs.github.com/en).

This patch fixes the capitalization to that convention across the project.