### PR TITLE
K01: Updates and corrections

### DIFF
--- a/2022/en/src/K01-insecure-workload-configurations.md
+++ b/2022/en/src/K01-insecure-workload-configurations.md
@@ -1,12 +1,12 @@
 ### Overview
 
-The security context of a workload in Kubernetes is highly configurable which can lead to serious security misconfigurations propagating across and organization’s workloads and clusters. The [2021 Kubernetes Security Survey](https://www.redhat.com/en/resources/kubernetes-adoption-security-market-trends-2021-overview) from Redhat stated that nearly 60% of respondents have experienced a misconfiguration incident in their Kubernetes environments in the last 12 months. 
+The security context of a workload in Kubernetes is highly configurable which can lead to serious security misconfigurations propagating across an organization’s workloads and clusters. The [Kubernetes adoption, security, and market trends report 2022](https://www.redhat.com/en/resources/kubernetes-adoption-security-market-trends-overview) from Redhat stated that nearly 53% of respondents have experienced a misconfiguration incident in their Kubernetes environments in the last 12 months.
 
 ### Description
 
 Kubernetes manifests contain many different configurations that can affect the reliability, security, and scalability of a given workload. These configurations should be audited and remediated continuously. Some examples of high-impact manifest configurations are below:
 
-**Application processes should not run as root:** Running the process inside of a container as the `root` user is a common misconfiguration in many clusters. While `root` may be an absolute requirement for some workloads, it should be avoided when possible. If the container were to be compromised, the attacker would have root-level privileges that allow actions such as starting a malicious process that otherwise wouldn’t be permitted with other users on the system. 
+**Application processes should not run as root:** Running the process inside of a container as the `root` user is a common misconfiguration in many clusters. While `root` may be an absolute requirement for some workloads, it should be avoided when possible. If the container were to be compromised, the attacker would have root-level privileges that allow actions such as starting a malicious process that otherwise wouldn’t be permitted with other users on the system.
 
 ```yaml
 apiVersion: v1  
@@ -20,9 +20,8 @@ spec:
     #root user
     runAsUser: 0
 	#non-root user
-	runAsUser: 5554	
+	runAsUser: 5554
 ```
-
 
 **Read-only filesystems should be used:** In order to limit the impact of a compromised container on a Kubernetes node, it is recommended to utilize read-only filesystems when possible. This prevents a malicious process or application from writing back to the host system. Read-only filesystems are a key component to preventing container breakout.
 
@@ -39,8 +38,7 @@ spec:
     readOnlyRootFilesystem: true
 ```
 
-
-**Privileged containers should be disallowed**: Setting a container to `privileged` within Kubernetes, the container itself can access additional resources and kernel capabilities of the host itself. Application system running as root combined with privileged containers is devastating as the user can get complete access to the host. This is , however , limited when running as non-root user.  Privileged containers are dangerous as they remove many of the built-in container isolation mechanisms entirely.  
+**Privileged containers should be disallowed**: When setting a container to `privileged` within Kubernetes, the container can access additional resources and kernel capabilities of the host. Workloads running as root combined with privileged containers can be devastating as the user can get complete access to the host. This is, however, limited when running as a non-root user. Privileged containers are dangerous as they remove many of the built-in container isolation mechanisms entirely.
 
 ```yaml
 apiVersion: v1  
@@ -59,20 +57,17 @@ spec:
 
 ### How to Prevent
 
-Maintaining secure configurations throughout a large, distributed Kubernetes environment can be a difficult task. While many security configurations are often set in the `securityContext` of the manifest itself there are a number of other misconfigurations that can be detected elsewhere. In order to prevent misconfigurations, they must first be detected in both runtime and in code. We can enforce the applications : 
+Maintaining secure configurations throughout a large, distributed Kubernetes environment can be a difficult task. While many security configurations are often set in the `securityContext` of the manifest itself there are a number of other misconfigurations that can be detected elsewhere. In order to prevent misconfigurations, they must first be detected in both runtime and in code. We can enforce that applications:
 
 1. Run as non-root user
 2. Run as non-privileged mode
 3. Set AllowPrivilegeEscalation: False to disallow child process from getting more privileges than its parents
 
-Tools such as Open Policy Agent can be used as a policy engine to detect these common misconfigurations. The CIS Benchmark for Kubernetes can also be used as a starting point for discovering misconfigurations. 
-
-
+Tools such as Open Policy Agent can be used as a policy engine to detect these common misconfigurations. The CIS Benchmark for Kubernetes can also be used as a starting point for discovering misconfigurations.
 
 ### Example Attack Scenarios
 
-
-
+TODO
 
 ### References
 


### PR DESCRIPTION
Waiting to mark this as ready until #39 and #40 are merged

- Update the K8s security survey link to point to 2022 release. 2021 link now redirects there. Also updates the report name and the response data based on the newer report.
- Made some small grammatical enhancements and removed some trailing whitespace.