### PR TITLE
Updated ClusterRoleBinding manifest to use rbac.authorization.k8s.io/…

### DIFF
--- a/2022/en/src/K03-overly-permissive-rbac.md
+++ b/2022/en/src/K03-overly-permissive-rbac.md
@@ -43,18 +43,18 @@ Execution) then it is trivial for the attacker to compromise the entire cluster
 by impersonating the service
 
 ```yaml
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
- name: redacted-rbac
+  name: redacted-rbac
 subjects:
- - kind: ServiceAccount
-   name: default
-   namespace: default
+- kind: ServiceAccount
+  name: default
+  namespace: default
 roleRef:
- kind: ClusterRole
- name: cluster-admin
- apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+  apiGroup: rbac.authorization.k8s.io
 ```
 
 ### How to Prevent


### PR DESCRIPTION
…v1 API version instead of v1beta1

I tried testing the ClusterRoleBinding resource and it failed.  Latest versions of Kubernetes do not supported the v1beta1 version of the rbac.authorization.k8s.io API. The Kubernetes API has evolved, and the v1beta1 version of the RBAC API appears to be outdated.