### PR TITLE
K06-broken-auth: Ingress object without TLS cert

### DIFF
--- a/2022/en/src/K06-broken-authentication.md
+++ b/2022/en/src/K06-broken-authentication.md
@@ -56,6 +56,38 @@ compromise or leak of private key material. Certificates are also more
 cumbersome to configure, sign, and distribute. A certificate may be used as a
 “Break Glass” authentication mechanism but not for primary auth.
 
+### Avoid Ingress Object Creation without TLS Certificates
+
+TLS certificates serve as a means of authenticating the server to the
+client. When an Ingress Object lacks TLS certificates, there is no
+assurance that the server the client is connecting to is legitimate.
+This opens the door for man-in-the-middle (MITM) attacks where attackers
+can intercept and impersonate the server, potentially leading to data
+theft or unauthorized access.
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: secure-ingress
+spec:
+  tls:
+    - hosts:
+        - example.com  # Replace with your domain
+      secretName: tls-secret  # Replace with the name of your TLS secret
+  rules:
+    - host: example.com  # Replace with your domain
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: your-service-name  # Replace with your backend service name
+                port:
+                  number: 80  # Replace with your service port number
+```
+
 ### Never roll your own authentication
 
 Just like crypto, you should not build something novel when it isn’t necessary.


### PR DESCRIPTION
Creating an Ingress Object without TLS certificates can be a security concern, as it may lead to potential vulnerabilities and data exposure. While TLS can be used for encryption, TLS also provides a level of authentication by verifying the identity of the server to which a client is connecting. This is done through the server presenting a digital certificate signed by a trusted Certificate Authority (CA). The client can verify the certificate to ensure that it is connecting to the legitimate server and not an imposter. Sadly, I don't have access to any threat research report statistics on this matter, however, this is generally considered a bad practice and should be included in the report, I believe.