### PR TITLE
fix: add missing .md extension to internal links

### DIFF
--- a/2025/en/src/info.md
+++ b/2025/en/src/info.md
@@ -5,7 +5,7 @@
 
 ### Top 10 Kubernetes Risks
 
-- [K01: Insecure Workload Configuration](./K01-Insecure-Workload-Configurations)
+- [K01: Insecure Workload Configuration](./K01-Insecure-Workload-Configurations.md)
 - [K02: Overly Permissive Authorization Configurations](./K02-Overly-Permissive-Authorization-Configurations.md)
 - [K03: Secrets Management Failures](./K03-Secrets-Management-Failures.md)
 - [K04: Lack Of Cluster Level Policy Enforcement](./K04-Lack-Of-Cluster-Level-Policy-Enforcement.md)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ When adopting [Kubernetes](https://kubernetes.io), we introduce new risks to our
 
 2025 Top 10 Risks now available Feedback welcome. Please open issues or PRs for changes
 
-- [K01: Insecure Workload Configurations](./2025/en/src/K01-Insecure-Workload-Configurations)
+- [K01: Insecure Workload Configurations](./2025/en/src/K01-Insecure-Workload-Configurations.md)
 - [K02: Overly Permissive Authorization Configurations](./2025/en/src/K02-Overly-Permissive-Authorization-Configurations.md)
 - [K03: Secrets Management Failures](./2025/en/src/K03-Secrets-Management-Failures.md)
 - [K04: Lack Of Cluster Level Policy Enforcement](./2025/en/src/K04-Lack-Of-Cluster-Level-Policy-Enforcement.md)

--- a/index.md
+++ b/index.md
@@ -16,7 +16,7 @@ When adopting [Kubernetes](https://kubernetes.io), we introduce new risks to our
 
 2025 Top 10 Risks now available Feedback welcome. Please open issues or PRs for changes
 
-- [K01: Insecure Workload Configurations](./2025/en/src/K01-Insecure-Workload-Configurations)
+- [K01: Insecure Workload Configurations](./2025/en/src/K01-Insecure-Workload-Configurations.md)
 - [K02: Overly Permissive Authorization Configurations](./2025/en/src/K02-Overly-Permissive-Authorization-Configurations.md)
 - [K03: Secrets Management Failures](./2025/en/src/K03-Secrets-Management-Failures.md)
 - [K04: Lack Of Cluster Level Policy Enforcement](./2025/en/src/K04-Lack-Of-Cluster-Level-Policy-Enforcement.md)


### PR DESCRIPTION
Hi,

I noticed that some links refering to the **K01: Insecure Workload Configuration** missing the `.md` which could lead to broken navigation.

I have updated the following files:
- README.md
- index.md
- 2025/en/src/info.md